### PR TITLE
Polish DJ timetable layout for 1–3 columns

### DIFF
--- a/src/data/dj/details/2022/Virtual00.ts
+++ b/src/data/dj/details/2022/Virtual00.ts
@@ -1,185 +1,186 @@
 import { EventDetail } from "@/types/EventDetail";
 
 export const event: EventDetail = {
-  
-  slug : "practice",
+  slug: "practice",
   title: "第一回 DJガチ初心者練習会",
-  date : {
-    year : 2022,
+  date: {
+    year: 2022,
     month: 2,
-    day  : 12
+    day: 12,
   },
   time: {
     start: "13:00",
-    end  : "16:00"
+    end: "16:00",
   },
   place: {
-    name    : "Instant DJ space Yellow Lab․",
-    url     : "https://vrchat.com/home/world/wrld_09dbcce6-c781-497d-a5b2-bf36f2a0f848/info",
+    name: "Instant DJ space Yellow Lab․",
+    url: "https://vrchat.com/home/world/wrld_09dbcce6-c781-497d-a5b2-bf36f2a0f848/info",
     platform: {
-      name    : "VRChat",
-      instance: "Friends+"
+      name: "VRChat",
+      instance: "Friends+",
     },
   },
   flyer: {
-    width : 960,
+    width: 960,
     height: 720,
-    image : "/dj/2022/djV00.avif"
+    image: "/dj/2022/djV00.avif",
   },
-  timeSlot: {
-    start   : "13:00",
-    end     : "16:00",
-    performs: [
-      {
-        start: "13:00",
-        end  : "14:00",
-        dj   : ["loser4dim"]
-      },
-      {
-        start: "14:00",
-        end  : "15:00",
-        dj   : ["あんにん"]
-      },
-      {
-        start: "15:00",
-        end  : "16:00",
-        dj   : ["DJ\"MAꓘKURO\""]
-      }
-    ]
-  },
+  timeSlot: [
+    {
+      start: "13:00",
+      end: "16:00",
+      performs: [
+        {
+          start: "13:00",
+          end: "14:00",
+          dj: ["loser4dim"],
+        },
+        {
+          start: "14:00",
+          end: "15:00",
+          dj: ["あんにん"],
+        },
+        {
+          start: "15:00",
+          end: "16:00",
+          dj: ['DJ"MAꓘKURO"'],
+        },
+      ],
+    },
+  ],
   organizers: [
     {
       name: "スパイラルポテトあきぺ",
-      url : "https://linktr.ee/vrdjakipe"
-    }
+      url: "https://linktr.ee/vrdjakipe",
+    },
   ],
   support: [
     {
-      role  : "DJ",
+      role: "DJ",
       performers: [
-        
         {
-          name: "DJ\"MAꓘKURO\"",
-          url : "https://x.com/Yu_vrc"
+          name: 'DJ"MAꓘKURO"',
+          url: "https://x.com/Yu_vrc",
         },
         {
-          name: "loser4dim"
+          name: "loser4dim",
         },
         {
           name: "あんにん",
-          url : "https://x.com/AnniN_CK"
-        }
-      ]
-    }
+          url: "https://x.com/AnniN_CK",
+        },
+      ],
+    },
   ],
   announcements: [
     {
       sns: "𝕏-Twitter",
-      url: "https://x.com/chemAkipeVR/status/1492130885025419264"
-    }
+      url: "https://x.com/chemAkipeVR/status/1492130885025419264",
+    },
   ],
   hashtags: ["DJガチ初心者練習会", "VRChat"],
   setlist: [
     {
-      index : 1,
+      index: 1,
       artist: "名取さな",
-      track : "アマカミサマ (itzi UK Hardcore Edit)",
-      url   : "https://soundcloud.com/ichii_egp/amakamisama-itzi-edit"
+      track: "アマカミサマ (itzi UK Hardcore Edit)",
+      url: "https://soundcloud.com/ichii_egp/amakamisama-itzi-edit",
     },
     {
-      index : 2,
+      index: 2,
       artist: "Illenium",
-      track : "Paper Thin (Headhunterz Remix) (6Tan Hardcore Bootleg)",
-      url   : "https://hypeddit.com/k48mny"
+      track: "Paper Thin (Headhunterz Remix) (6Tan Hardcore Bootleg)",
+      url: "https://hypeddit.com/k48mny",
     },
     {
-      index : 3,
+      index: 3,
       artist: "EBIMAYO",
-      track : "Chicken Race",
-      url   : "https://ab-sounds.bandcamp.com/track/chicken-race"
+      track: "Chicken Race",
+      url: "https://ab-sounds.bandcamp.com/track/chicken-race",
     },
     {
-      index : 4,
+      index: 4,
       artist: "Noizenecio feat. MC Dahl Headland",
-      track : "Overload",
-      url   : "https://tanoc.bandcamp.com/track/overload"
+      track: "Overload",
+      url: "https://tanoc.bandcamp.com/track/overload",
     },
     {
-      index : 5,
+      index: 5,
       artist: "Ryu☆",
-      track : "Breeze",
-      url   : "https://tanoc.bandcamp.com/track/breeze"
+      track: "Breeze",
+      url: "https://tanoc.bandcamp.com/track/breeze",
     },
     {
-      index : 6,
+      index: 6,
       artist: "Takahiro Aoki",
-      track : "S.Y.F (Extended Edit)",
-      url   : "https://sbfr.bandcamp.com/track/s-y-f-extended-edit"
+      track: "S.Y.F (Extended Edit)",
+      url: "https://sbfr.bandcamp.com/track/s-y-f-extended-edit",
     },
     {
-      index : 7,
+      index: 7,
       artist: "宮内遊園地, 八木山遊園地",
-      track : "オールドスクールハッピーハードコアブレイクビーツブンブンパイレーツパラダイス",
-      url   : "http://maltinerecords.cs8.biz/101.html"
+      track:
+        "オールドスクールハッピーハードコアブレイクビーツブンブンパイレーツパラダイス",
+      url: "http://maltinerecords.cs8.biz/101.html",
     },
     {
-      index : 8,
+      index: 8,
       artist: "7_7(ゴミ箱)",
-      track : "からーずぱわー？？？",
-      url   : "https://soundcloud.com/7_7trushcan/wfpmf2tkar84"
+      track: "からーずぱわー？？？",
+      url: "https://soundcloud.com/7_7trushcan/wfpmf2tkar84",
     },
     {
-      index : 9,
+      index: 9,
       artist: "P丸様。",
-      track : "シル・ヴ・プレジデント (6Tan Bootleg)",
-      url   : "https://hypeddit.com/track/byidb2"
+      track: "シル・ヴ・プレジデント (6Tan Bootleg)",
+      url: "https://hypeddit.com/track/byidb2",
     },
     {
-      index : 10,
+      index: 10,
       artist: "maguro",
-      track : "音楽1 (7_7 remix www)",
-      url   : "https://soundcloud.com/7_7-nananana/maguro869-1-7_7-remix-www"
+      track: "音楽1 (7_7 remix www)",
+      url: "https://soundcloud.com/7_7-nananana/maguro869-1-7_7-remix-www",
     },
     {
-      index : 11,
+      index: 11,
       artist: "AOiRO_Manbow",
-      track : "DEAD END OF SMASH ROAD",
-      url   : "https://sbfr.bandcamp.com/track/dead-end-of-smash-road"
+      track: "DEAD END OF SMASH ROAD",
+      url: "https://sbfr.bandcamp.com/track/dead-end-of-smash-road",
     },
     {
-      index : 12,
+      index: 12,
       artist: "Kanaria feat. GUMI",
-      track : "KING (栄免建設 Renovation)",
-      url   : "https://karent.jp/cd/digitalstarsmg"
+      track: "KING (栄免建設 Renovation)",
+      url: "https://karent.jp/cd/digitalstarsmg",
     },
     {
-      index : 13,
+      index: 13,
       artist: "Ryu☆, L.E.D.-G",
-      track : "PARADISE LOST (STARLiGHT Mix)",
-      url   : "https://www.konamistyle.jp/products/detail.php?product_id=73293"
+      track: "PARADISE LOST (STARLiGHT Mix)",
+      url: "https://www.konamistyle.jp/products/detail.php?product_id=73293",
     },
     {
-      index : 14,
+      index: 14,
       artist: "かめりあ feat. ななひら",
-      track : "インターネットが遅いさん (Super-Slow-Internet-san)",
-      url   : "https://nanahira.jp/goin/"
+      track: "インターネットが遅いさん (Super-Slow-Internet-san)",
+      url: "https://nanahira.jp/goin/",
     },
     {
-      index : 15,
+      index: 15,
       artist: "wowaka feat. 初音ミク",
-      track : "ローリンガール 風林火山編 (by acane_madder)",
-      url   : "https://tower.jp/item/2861317"
+      track: "ローリンガール 風林火山編 (by acane_madder)",
+      url: "https://tower.jp/item/2861317",
     },
     {
-      index : 16,
+      index: 16,
       artist: "Emma",
-      track : "B0RN 4G41N",
-      url   : "https://nonstopnxc.bandcamp.com/track/nxc058-emma-b0rn-4g41n"
-    }
+      track: "B0RN 4G41N",
+      url: "https://nonstopnxc.bandcamp.com/track/nxc058-emma-b0rn-4g41n",
+    },
   ],
   galleryTwitter: [
     "1492130885025419264",
     "1492325386306437124",
-    "1492355437441974272"
-  ]
+    "1492355437441974272",
+  ],
 };

--- a/src/data/dj/details/2022/Virtual1.ts
+++ b/src/data/dj/details/2022/Virtual1.ts
@@ -1,256 +1,261 @@
 import { EventDetail } from "@/types/EventDetail";
 
 export const event: EventDetail = {
-  slug : "dj-unknown-1",
+  slug: "dj-unknown-1",
   title: "DJなんもわからん EP.7",
-  date : {
-    year : 2022,
+  date: {
+    year: 2022,
     month: 3,
-    day  : 3
+    day: 3,
   },
   time: {
     start: "20:45",
-    end  : "23:40"
+    end: "23:40",
   },
   place: {
-    name    : "ClubUnknown 3rd",
+    name: "ClubUnknown 3rd",
     platform: {
-      name    : "VRChat",
-      instance: "Friends+"
+      name: "VRChat",
+      instance: "Friends+",
     },
   },
   flyer: {
-    width : 1439,
+    width: 1439,
     height: 2036,
-    image : "/dj/2022/djV1.avif"
+    image: "/dj/2022/djV1.avif",
   },
   organizers: [
     {
       name: "RcXvr_ブラッコリー",
-      url : "https://x.com/ClubUnknown_vrc"
-    }
+      url: "https://x.com/ClubUnknown_vrc",
+    },
   ],
-  support : [
+  support: [
     {
-      role  : "DJ",
+      role: "DJ",
       performers: [
         {
           name: "GENOA：げのあ",
-          url : ""
+          url: "",
         },
         {
-          name: "loser4dim"
+          name: "loser4dim",
         },
         {
           name: "micazuki",
-          url : ""
+          url: "",
         },
-        
+
         {
           name: "餅屋",
-          url : ""
-        }
-      ]
+          url: "",
+        },
+      ],
     },
     {
-      role  : "VJ",
+      role: "VJ",
       performers: [
         {
-          name: "Mano.Hsmt"
+          name: "Mano.Hsmt",
         },
         {
           name: "meg_vj_",
-          url : ""
-        }
-      ]
-    }
+          url: "",
+        },
+      ],
+    },
   ],
   announcements: [
     {
       sns: "𝕏-Twitter",
-      url: "https://x.com/ClubUnknown_vrc/status/1497520107203211265"
-    }
+      url: "https://x.com/ClubUnknown_vrc/status/1497520107203211265",
+    },
   ],
   hashtags: ["VRC_DJなんもわからん", "VRCUnknown", "VRChat"],
-  timeSlot: {
-    start   : "21:00",
-    end     : "24:00",
-    performs: [
-      {
-        start: "21:00",
-        end  : "21:40",
-        dj   : ["loser4dim"],
-        vj   : ["Mano.Hsmt"]
-      },
-      {
-        start: "21:40",
-        end  : "22:20",
-        dj   : ["micazuki"],
-        vj   : ["Mano.Hsmt"]
-      },
-      {
-        start: "22:20",
-        end  : "23:00",
-        dj   : ["餅屋"],
-        vj   : ["meg_vj_"]
-      },
-      {
-        start: "23:00",
-        end  : "23:40",
-        dj   : ["GENOA：げのあ"],
-        vj   : ["meg_vj_"]
-      }
-    ]
-  },
+  timeSlot: [
+    {
+      start: "21:00",
+      end: "24:00",
+      performs: [
+        {
+          start: "21:00",
+          end: "21:40",
+          dj: ["loser4dim"],
+          vj: ["Mano.Hsmt"],
+        },
+        {
+          start: "21:40",
+          end: "22:20",
+          dj: ["micazuki"],
+          vj: ["Mano.Hsmt"],
+        },
+        {
+          start: "22:20",
+          end: "23:00",
+          dj: ["餅屋"],
+          vj: ["meg_vj_"],
+        },
+        {
+          start: "23:00",
+          end: "23:40",
+          dj: ["GENOA：げのあ"],
+          vj: ["meg_vj_"],
+        },
+      ],
+    },
+  ],
   mixArchives: [
     {
-      type    : "mixcloud",
-      embedUrl: "https://player-widget.mixcloud.com/widget/iframe/?light=1&feed=%2Floser4dim%2F2022_3_3dj%25E3%2581%25AA%25E3%2582%2593%25E3%2582%2582%25E3%2582%258F%25E3%2581%258B%25E3%2582%2589%25E3%2582%2593ep7%2F"
+      type: "mixcloud",
+      embedUrl:
+        "https://player-widget.mixcloud.com/widget/iframe/?light=1&feed=%2Floser4dim%2F2022_3_3dj%25E3%2581%25AA%25E3%2582%2593%25E3%2582%2582%25E3%2582%258F%25E3%2581%258B%25E3%2582%2589%25E3%2582%2593ep7%2F",
     },
     {
-      type    : "cloudflare",
-      embedUrl: "https://pub-e92c9f52ee8b4ad98efb0d3b0619305c.r2.dev/2025/2025-6-28-DeepBlue.opus"
+      type: "cloudflare",
+      embedUrl:
+        "https://pub-e92c9f52ee8b4ad98efb0d3b0619305c.r2.dev/2025/2025-6-28-DeepBlue.opus",
     },
   ],
   setlist: [
     {
-      index : 1,
+      index: 1,
       artist: "ユニティちゃん",
-      track : "宜しくお願いしまーす！",
-      url   : "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack"
+      track: "宜しくお願いしまーす！",
+      url: "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack",
     },
     {
-      index : 2,
+      index: 2,
       artist: "Kabanagu",
-      track : "はじまり",
-      url   : "http://maltinerecords.cs8.biz/183.html"
+      track: "はじまり",
+      url: "http://maltinerecords.cs8.biz/183.html",
     },
     {
-      index : 3,
+      index: 3,
       artist: "Quok",
-      track : "Atariwave",
-      url   : "https://nightowlcollective.bandcamp.com/album/quok-atariwave"
+      track: "Atariwave",
+      url: "https://nightowlcollective.bandcamp.com/album/quok-atariwave",
     },
     {
-      index : 4,
+      index: 4,
       artist: "kugumo",
-      track : "	線路",
-      url   : "https://booth.pm/ja/items/376570"
+      track: "	線路",
+      url: "https://booth.pm/ja/items/376570",
     },
     {
-      index : 5,
+      index: 5,
       artist: "DJ.DAI",
-      track : "Sampling Shakin' 20 (Musicarus Remix)",
-      url   : "https://www.trekkie-trax.com/ep/trekkie10/"
+      track: "Sampling Shakin' 20 (Musicarus Remix)",
+      url: "https://www.trekkie-trax.com/ep/trekkie10/",
     },
     {
-      index : 6,
+      index: 6,
       artist: "Environments",
-      track : "The Psychologically Ultimate Seashore",
-      url   : "https://numeroenvironments.bandcamp.com/track/the-psychologically-ultimate-seashore"
+      track: "The Psychologically Ultimate Seashore",
+      url: "https://numeroenvironments.bandcamp.com/track/the-psychologically-ultimate-seashore",
     },
     {
-      index : 7,
+      index: 7,
       artist: "gaburyu feat. 初音ミク",
-      track : "swim (Alicemetix Remix)",
-      url   : "https://soundcloud.com/alicemetix/swim"
+      track: "swim (Alicemetix Remix)",
+      url: "https://soundcloud.com/alicemetix/swim",
     },
     {
-      index : 8,
+      index: 8,
       artist: "Miniland",
-      track : "My Life",
-      url   : "https://aviencloudrecords.bandcamp.com/track/my-life"
+      track: "My Life",
+      url: "https://aviencloudrecords.bandcamp.com/track/my-life",
     },
     {
-      index : 9,
+      index: 9,
       artist: "パソコン音楽クラブ feat. Tomoyuki Sagesaka",
-      track : "Locator",
-      url   : "https://see-voice.pasoconongaku.club/"
+      track: "Locator",
+      url: "https://see-voice.pasoconongaku.club/",
     },
     {
-      index : 10,
+      index: 10,
       artist: "Heavenz feat. 初音ミク",
-      track : "Fondant Step",
-      url   : "https://karent.jp/cd/16"
+      track: "Fondant Step",
+      url: "https://karent.jp/cd/16",
     },
     {
-      index : 11,
+      index: 11,
       artist: "Neko Hacker feat. 利香",
-      track : "Sweet Dreams",
-      url   : "https://nekohacker.bandcamp.com/track/sweet-dreams-feat-rika"
+      track: "Sweet Dreams",
+      url: "https://nekohacker.bandcamp.com/track/sweet-dreams-feat-rika",
     },
     {
-      index : 12,
+      index: 12,
       artist: "Fellsius",
-      track : "Talk",
-      url   : "https://www.trekkie-trax.com/ep/trekkie152/"
+      track: "Talk",
+      url: "https://www.trekkie-trax.com/ep/trekkie152/",
     },
     {
-      index : 13,
+      index: 13,
       artist: "0b4k3 feat. kinu",
-      track : "voices",
-      url   : "https://0b4k3.bandcamp.com/track/voices-feat-kinu"
+      track: "voices",
+      url: "https://0b4k3.bandcamp.com/track/voices-feat-kinu",
     },
     {
-      index : 14,
+      index: 14,
       artist: "Carpainter",
-      track : "WAR DUB FROM THE NEW WORLD",
-      url   : "https://www.trekkie-trax.com/ep/trekkie12/"
+      track: "WAR DUB FROM THE NEW WORLD",
+      url: "https://www.trekkie-trax.com/ep/trekkie12/",
     },
     {
-      index : 15,
+      index: 15,
       artist: "you",
-      track : "Party Catapult",
-      url   : "https://lilium-rec.com/rave2/"
+      track: "Party Catapult",
+      url: "https://lilium-rec.com/rave2/",
     },
     {
-      index : 16,
+      index: 16,
       artist: "I WiSH",
-      track : "明日への扉 (山田結衣 & 加瀬友香 Cover) (Kacky 90's Style HappyHardcore Bootleg)",
-      url   : "https://soundcloud.com/kacky124/kacky-90s-style-happyhardcore-bootleg"
+      track:
+        "明日への扉 (山田結衣 & 加瀬友香 Cover) (Kacky 90's Style HappyHardcore Bootleg)",
+      url: "https://soundcloud.com/kacky124/kacky-90s-style-happyhardcore-bootleg",
     },
     {
-      index : 17,
+      index: 17,
       artist: "ETIA. feat. Jenga",
-      track : "On And On!! (Groundbreaking Edit)",
-      url   : "https://gdbg.tv/release/2018-8-2"
+      track: "On And On!! (Groundbreaking Edit)",
+      url: "https://gdbg.tv/release/2018-8-2",
     },
     {
-      index : 18,
+      index: 18,
       artist: "IOSYS TRAX, ちよこ",
-      track : "超野生！サバイバルずんど子ちゃん (Extended Mix)",
-      url   : "https://www.iosysos.com/discographyportal.php?cdno=IOTX-0006"
+      track: "超野生！サバイバルずんど子ちゃん (Extended Mix)",
+      url: "https://www.iosysos.com/discographyportal.php?cdno=IOTX-0006",
     },
     {
-      index : 19,
+      index: 19,
       artist: "NJ zEn",
-      track : "プルプルAction! シュランツ消臭ポッド",
-      url   : "https://dochakuso.net/release/dcks-0001.html"
+      track: "プルプルAction! シュランツ消臭ポッド",
+      url: "https://dochakuso.net/release/dcks-0001.html",
     },
     {
-      index : 20,
+      index: 20,
       artist: "Alicemetix",
-      track : "ラーメン二郎みたいなマッシュアップ",
-      url   : "https://soundcloud.com/mr_aaaa/jirou-mashup"
+      track: "ラーメン二郎みたいなマッシュアップ",
+      url: "https://soundcloud.com/mr_aaaa/jirou-mashup",
     },
     {
-      index : 21,
+      index: 21,
       artist: "Miniland",
-      track : "My Life",
-      url   : "https://aviencloudrecords.bandcamp.com/track/my-life"
+      track: "My Life",
+      url: "https://aviencloudrecords.bandcamp.com/track/my-life",
     },
     {
-      index : 22,
+      index: 22,
       artist: "Cab Calloway, Frank Froebe, Jack Palme",
-      track : "Jumpin' Jive (Played by 東京ディズニーシー ビッグバンドビート)",
-      url   : "https://www.universal-music.co.jp/p/uwcd-8119/"
+      track: "Jumpin' Jive (Played by 東京ディズニーシー ビッグバンドビート)",
+      url: "https://www.universal-music.co.jp/p/uwcd-8119/",
     },
     {
-      index : 23,
+      index: 23,
       artist: "ユニティちゃん",
-      track : "ありがとうございましたー！",
-      url   : "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack"
-    }
+      track: "ありがとうございましたー！",
+      url: "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack",
+    },
   ],
   galleryTwitter: [
     "1497520107203211265",
@@ -272,6 +277,6 @@ export const event: EventDetail = {
     "1499389603945467913",
     "1499388406048051201",
     "1499409304642011138",
-    "1499444836910321664"
-  ]
+    "1499444836910321664",
+  ],
 };

--- a/src/data/dj/details/2025/Real19.ts
+++ b/src/data/dj/details/2025/Real19.ts
@@ -1,237 +1,239 @@
 import { EventDetail } from "@/types/EventDetail";
 
 export const event: EventDetail = {
-  slug : "magnum-tornado-1",
+  slug: "magnum-tornado-1",
   title: "MAGNUM TORNADO LAP3",
-  date : {
-    year : 2025,
+  date: {
+    year: 2025,
     month: 12,
-    day  : 6
+    day: 6,
   },
   time: {
     start: "12:00",
-    end  : "18:00"
+    end: "18:00",
   },
   place: {
-    name: "B.B.Q rave kitchen Mediterraneo casa"
+    name: "B.B.Q rave kitchen Mediterraneo casa",
   },
   flyer: {
-    width : 2894,
+    width: 2894,
     height: 4093,
-    image : "/dj/2025/2025-Real-9.avif"
+    image: "/dj/2025/2025-Real-9.avif",
   },
   organizers: [
     {
       name: "suikoko",
-      url : "https://linktr.ee/sainann"
-    }
+      url: "https://linktr.ee/sainann",
+    },
   ],
-  support : [
+  support: [
     {
-      role  : "DJ",
+      role: "DJ",
       performers: [
         {
           name: "komezi",
-          url : "https://lit.link/komezi"
+          url: "https://lit.link/komezi",
         },
         {
           name: "MadaMerica",
-          url : "https://linktr.ee/madamerica"
+          url: "https://linktr.ee/madamerica",
         },
         {
           name: "Marifu",
-          url : "https://marifu.love/"
+          url: "https://marifu.love/",
         },
         {
           name: "Nin",
-          url : "https://x.com/Nin2_0510"
+          url: "https://x.com/Nin2_0510",
         },
         {
           name: "SYNE.",
-          url : "https://potofu.me/syakedaniel"
+          url: "https://potofu.me/syakedaniel",
         },
         {
           name: "ねこたん",
-          url : "https://x.com/VRCaccount1"
+          url: "https://x.com/VRCaccount1",
         },
         {
           name: "早川あおせ",
-          url : "https://hykwaose.tumblr.com/"
+          url: "https://hykwaose.tumblr.com/",
         },
         {
           name: "ろーすとぽてと",
-          url : "https://lit.link/RoastPotato"
+          url: "https://lit.link/RoastPotato",
         },
         {
-          name: "loser4dim"
-        }
-      ]
+          name: "loser4dim",
+        },
+      ],
     },
     {
-      role  : "VJ",
+      role: "VJ",
       performers: [
         {
           name: "himachi",
-          url : "https://x.com/himatchi_vrc"
+          url: "https://x.com/himatchi_vrc",
         },
-         {
+        {
           name: "切り昆布",
-          url : "https://x.com/cutseaweed_vrc"
-        }
-      ]
+          url: "https://x.com/cutseaweed_vrc",
+        },
+      ],
     },
   ],
   announcements: [
     {
       sns: "𝕏-Twitter",
-      url: "https://x.com/sainann/status/1995329584410296761"
-    }
+      url: "https://x.com/sainann/status/1995329584410296761",
+    },
   ],
-  timeSlot: {
-    start   : "12:00",
-    end     : "18:00",
-    performs: [
-      {
-        start: "12:00",
-        end  : "12:40",
-        dj   : ["早川あおせ"],
-        vj   : ["切り昆布"]
-      },
-      {
-        start: "12:40",
-        end  : "13:20",
-        dj   : ["ねこたん"],
-        vj   : ["切り昆布"]
-      },
-      {
-        start: "13:20",
-        end  : "14:00",
-        dj   : ["komezi"],
-        vj   : ["himachi"]
-      },
-      {
-        start: "14:00",
-        end  : "14:40",
-        dj   : ["loser4dim"],
-        vj   : ["himachi"]
-      },
-      {
-        start: "14:40",
-        end  : "15:20",
-        dj   : ["MadaMerica"],
-        vj   : ["切り昆布"]
-      },
-      {
-        start: "15:20",
-        end  : "16:00",
-        dj   : ["marifu"],
-        vj   : ["切り昆布"]
-      },
-      {
-        start: "16:00",
-        end  : "16:40",
-        dj   : ["ろーすとぽてと"],
-        vj   : ["切り昆布"]
-      },
-      {
-        start: "16:40",
-        end  : "17:20",
-        dj   : ["Nin"],
-        vj   : ["himachi"]
-      },
-      {
-        start: "17:20",
-        end  : "18:00",
-        dj   : ["SYNE."],
-        vj   : ["himachi"]
-      }
-    ]
-  },
+  timeSlot: [
+    {
+      start: "12:00",
+      end: "18:00",
+      performs: [
+        {
+          start: "12:00",
+          end: "12:40",
+          dj: ["早川あおせ"],
+          vj: ["切り昆布"],
+        },
+        {
+          start: "12:40",
+          end: "13:20",
+          dj: ["ねこたん"],
+          vj: ["切り昆布"],
+        },
+        {
+          start: "13:20",
+          end: "14:00",
+          dj: ["komezi"],
+          vj: ["himachi"],
+        },
+        {
+          start: "14:00",
+          end: "14:40",
+          dj: ["loser4dim"],
+          vj: ["himachi"],
+        },
+        {
+          start: "14:40",
+          end: "15:20",
+          dj: ["MadaMerica"],
+          vj: ["切り昆布"],
+        },
+        {
+          start: "15:20",
+          end: "16:00",
+          dj: ["marifu"],
+          vj: ["切り昆布"],
+        },
+        {
+          start: "16:00",
+          end: "16:40",
+          dj: ["ろーすとぽてと"],
+          vj: ["切り昆布"],
+        },
+        {
+          start: "16:40",
+          end: "17:20",
+          dj: ["Nin"],
+          vj: ["himachi"],
+        },
+        {
+          start: "17:20",
+          end: "18:00",
+          dj: ["SYNE."],
+          vj: ["himachi"],
+        },
+      ],
+    },
+  ],
   setlist: [
     {
-      index : 0,
+      index: 0,
       artist: "ユニティちゃん",
-      track : "宜しくお願いしまーす！",
-      url   : "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack"
+      track: "宜しくお願いしまーす！",
+      url: "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack",
     },
     {
-      index : 1,
+      index: 1,
       artist: "DJ Heero Yuy",
-      track : "legend of Japanese soul singer WADA",
-      url   : "https://soundcloud.com/dj_heero_yuy/legend-of-japanese-soul-singer-wada"
+      track: "legend of Japanese soul singer WADA",
+      url: "https://soundcloud.com/dj_heero_yuy/legend-of-japanese-soul-singer-wada",
     },
     {
-      index : 2,
+      index: 2,
       artist: "De La Soul feat. Chaka Khan",
-      track : "all good? (mj cole remix)",
-      url   : "https://www.sonymusic.co.jp/artist/Compilation/discography/AICT-164"
+      track: "all good? (mj cole remix)",
+      url: "https://www.sonymusic.co.jp/artist/Compilation/discography/AICT-164",
     },
     {
-      index : 3,
+      index: 3,
       artist: "That Fancy I / 花譜, キズナアイ",
-      track : "Poppin x かりそめ (e4 Mashup)",
-      url   : "https://soundcloud.com/user-1100946"
+      track: "Poppin x かりそめ (e4 Mashup)",
+      url: "https://soundcloud.com/user-1100946",
     },
     {
-      index : 4,
+      index: 4,
       artist: "Pete Heller",
-      track : "Big Love (Carpainter Funky Groove Mix)",
-      url   : "https://soundcloud.com/carpainter/pete-heller-big-love-carpainter-funky-groove-mixfree-download"
+      track: "Big Love (Carpainter Funky Groove Mix)",
+      url: "https://soundcloud.com/carpainter/pete-heller-big-love-carpainter-funky-groove-mixfree-download",
     },
     {
-      index : 5,
+      index: 5,
       artist: "NOLEMON NOMELON",
-      track : "どうにかなっちゃいそう！ (Bowne Bootleg)",
-      url   : "https://soundcloud.com/bowne_dj/nolemon-nomelon-bowne-bootleg"
+      track: "どうにかなっちゃいそう！ (Bowne Bootleg)",
+      url: "https://soundcloud.com/bowne_dj/nolemon-nomelon-bowne-bootleg",
     },
     {
-      index : 6,
+      index: 6,
       artist: "前川みく",
-      track : "おねだり Shall We ～？ (Kur@ra \"Onedari Dub\" Mix)",
-      url   : "https://soundcloud.com/miku_maekawa/onedari-dub"
+      track: 'おねだり Shall We ～？ (Kur@ra "Onedari Dub" Mix)',
+      url: "https://soundcloud.com/miku_maekawa/onedari-dub",
     },
     {
-      index : 7,
+      index: 7,
       artist: "Scatman John",
-      track : "Scatman (Game Over Jazz)",
-      url   : "https://tower.jp/item/144055"
+      track: "Scatman (Game Over Jazz)",
+      url: "https://tower.jp/item/144055",
     },
     {
-      index : 8,
+      index: 8,
       artist: "The Ohm",
-      track : "sing sing sing",
-      url   : "https://www.trekkie-trax.com/ep/trekkie13/"
+      track: "sing sing sing",
+      url: "https://www.trekkie-trax.com/ep/trekkie13/",
     },
     {
-      index : 9,
+      index: 9,
       artist: "DJ FUNK",
-      track : "Circut Breaker (DJ Amar Rework)",
-      url   : "https://djfunk1.bandcamp.com/album/dj-funk-gold-20th-anniversary-24bit-update"
+      track: "Circut Breaker (DJ Amar Rework)",
+      url: "https://djfunk1.bandcamp.com/album/dj-funk-gold-20th-anniversary-24bit-update",
     },
     {
-      index : 10,
+      index: 10,
       artist: "higma",
-      track : "echo (ABSMbootleg)",
-      url   : "https://soundcloud.com/abe-some/freedl-echo-absmbootleg"
+      track: "echo (ABSMbootleg)",
+      url: "https://soundcloud.com/abe-some/freedl-echo-absmbootleg",
     },
     {
-      index : 11,
+      index: 11,
       artist: "higma feat. 星宮とと",
-      track : "PAPERMOON",
-      url   : "https://theluvbugs.lnk.to/PAPERMOON"
+      track: "PAPERMOON",
+      url: "https://theluvbugs.lnk.to/PAPERMOON",
     },
     {
-      index : 12,
+      index: 12,
       artist: "篠澤広",
-      track : "光景 (sibitto Remix)",
-      url   : "https://soundcloud.com/sibitto/sibitto-remix"
+      track: "光景 (sibitto Remix)",
+      url: "https://soundcloud.com/sibitto/sibitto-remix",
     },
     {
-      index : 13,
+      index: 13,
       artist: "ユニティちゃん",
-      track : "ありがとうございましたー！",
-      url   : "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack"
-    }
+      track: "ありがとうございましたー！",
+      url: "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack",
+    },
   ],
   galleryTwitter: [
     "1995329584410296761",
@@ -258,6 +260,6 @@ export const event: EventDetail = {
     "1997158960210850053",
     "1997218843492864025",
     "1997140196702490951",
-    "1997193444356460651"
-  ]
+    "1997193444356460651",
+  ],
 };

--- a/src/data/dj/details/2025/Virtual209.ts
+++ b/src/data/dj/details/2025/Virtual209.ts
@@ -1,221 +1,225 @@
 import { EventDetail } from "@/types/EventDetail";
 
 export const event: EventDetail = {
-  slug : "mellons-afterlives-26",
+  slug: "mellons-afterlives-26",
   title: "méllon's afterlives #258",
-  date : {
-    year : 2025,
+  date: {
+    year: 2025,
     month: 9,
-    day  : 18
+    day: 18,
   },
   time: {
     start: "22:00",
-    end  : "24:00"
+    end: "24:00",
   },
   place: {
-    name    : "SoundBar Méllon",
+    name: "SoundBar Méllon",
     platform: {
-      name    : "VRChat",
-      instance: "Group Public"
+      name: "VRChat",
+      instance: "Group Public",
     },
   },
   flyer: {
-    width : 1439,
+    width: 1439,
     height: 2036,
-    image : "/dj/2022/djV1.avif"
+    image: "/dj/2022/djV1.avif",
   },
   organizers: [
     {
       name: "afafmy",
-      url : "https://x.com/0xA823"
+      url: "https://x.com/0xA823",
     },
     {
       name: "Q330",
-      url : "https://x.com/q330vrc"
-    }
+      url: "https://x.com/q330vrc",
+    },
   ],
-  support : [
+  support: [
     {
-      role  : "DJ",
+      role: "DJ",
       performers: [
         {
           name: "Ryoca",
-          url : "https://x.com/ryoca_knot"
+          url: "https://x.com/ryoca_knot",
         },
         {
-          name: "loser4dim"
-        }
-      ]
-    }
+          name: "loser4dim",
+        },
+      ],
+    },
   ],
   announcements: [
     {
       sns: "𝕏-Twitter",
-      url: "https://x.com/q330vrc/status/1968610481318269272"
-    }
+      url: "https://x.com/q330vrc/status/1968610481318269272",
+    },
   ],
   hashtags: ["SoundbarMéllon ", "VRChat"],
-  timeSlot: {
-    start   : "22:00",
-    end     : "24:00",
-    performs: [
-      {
-        start: "22:00",
-        end  : "23:00",
-        dj   : ["Ryoca"]
-      },
-      {
-        start: "23:00",
-        end  : "24:00",
-        dj   : ["loser4dim"]
-      }
-    ]
-  },
+  timeSlot: [
+    {
+      start: "22:00",
+      end: "24:00",
+      performs: [
+        {
+          start: "22:00",
+          end: "23:00",
+          dj: ["Ryoca"],
+        },
+        {
+          start: "23:00",
+          end: "24:00",
+          dj: ["loser4dim"],
+        },
+      ],
+    },
+  ],
   mixArchives: [
     {
-      type    : "mixcloud",
-      embedUrl: "https://player-widget.mixcloud.com/widget/iframe/?light=1&feed=%2Floser4dim%2F2022_3_3dj%25E3%2581%25AA%25E3%2582%2593%25E3%2582%2582%25E3%2582%258F%25E3%2581%258B%25E3%2582%2589%25E3%2582%2593ep7%2F"
-    }
+      type: "mixcloud",
+      embedUrl:
+        "https://player-widget.mixcloud.com/widget/iframe/?light=1&feed=%2Floser4dim%2F2022_3_3dj%25E3%2581%25AA%25E3%2582%2593%25E3%2582%2582%25E3%2582%258F%25E3%2581%258B%25E3%2582%2589%25E3%2582%2593ep7%2F",
+    },
   ],
   setlist: [
     {
-      index : 1,
+      index: 1,
       artist: "ユニティちゃん",
-      track : "宜しくお願いしまーす！",
-      url   : "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack"
+      track: "宜しくお願いしまーす！",
+      url: "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack",
     },
     {
-      index : 2,
+      index: 2,
       artist: "Kabanagu",
-      track : "はじまり",
-      url   : "http://maltinerecords.cs8.biz/183.html"
+      track: "はじまり",
+      url: "http://maltinerecords.cs8.biz/183.html",
     },
     {
-      index : 3,
+      index: 3,
       artist: "Quok",
-      track : "Atariwave",
-      url   : "https://nightowlcollective.bandcamp.com/album/quok-atariwave"
+      track: "Atariwave",
+      url: "https://nightowlcollective.bandcamp.com/album/quok-atariwave",
     },
     {
-      index : 4,
+      index: 4,
       artist: "kugumo",
-      track : "	線路",
-      url   : "https://booth.pm/ja/items/376570"
+      track: "	線路",
+      url: "https://booth.pm/ja/items/376570",
     },
     {
-      index : 5,
+      index: 5,
       artist: "DJ.DAI",
-      track : "Sampling Shakin' 20 (Musicarus Remix)",
-      url   : "https://www.trekkie-trax.com/ep/trekkie10/"
+      track: "Sampling Shakin' 20 (Musicarus Remix)",
+      url: "https://www.trekkie-trax.com/ep/trekkie10/",
     },
     {
-      index : 6,
+      index: 6,
       artist: "Environments",
-      track : "The Psychologically Ultimate Seashore",
-      url   : "https://numeroenvironments.bandcamp.com/track/the-psychologically-ultimate-seashore"
+      track: "The Psychologically Ultimate Seashore",
+      url: "https://numeroenvironments.bandcamp.com/track/the-psychologically-ultimate-seashore",
     },
     {
-      index : 7,
+      index: 7,
       artist: "gaburyu feat. 初音ミク",
-      track : "swim (Alicemetix Remix)",
-      url   : "https://soundcloud.com/alicemetix/swim"
+      track: "swim (Alicemetix Remix)",
+      url: "https://soundcloud.com/alicemetix/swim",
     },
     {
-      index : 8,
+      index: 8,
       artist: "Miniland",
-      track : "My Life",
-      url   : "https://aviencloudrecords.bandcamp.com/track/my-life"
+      track: "My Life",
+      url: "https://aviencloudrecords.bandcamp.com/track/my-life",
     },
     {
-      index : 9,
+      index: 9,
       artist: "パソコン音楽クラブ feat. Tomoyuki Sagesaka",
-      track : "Locator",
-      url   : "https://see-voice.pasoconongaku.club/"
+      track: "Locator",
+      url: "https://see-voice.pasoconongaku.club/",
     },
     {
-      index : 10,
+      index: 10,
       artist: "Heavenz feat. 初音ミク",
-      track : "Fondant Step",
-      url   : "https://karent.jp/cd/16"
+      track: "Fondant Step",
+      url: "https://karent.jp/cd/16",
     },
     {
-      index : 11,
+      index: 11,
       artist: "Neko Hacker feat. 利香",
-      track : "Sweet Dreams",
-      url   : "https://nekohacker.bandcamp.com/track/sweet-dreams-feat-rika"
+      track: "Sweet Dreams",
+      url: "https://nekohacker.bandcamp.com/track/sweet-dreams-feat-rika",
     },
     {
-      index : 12,
+      index: 12,
       artist: "Fellsius",
-      track : "Talk",
-      url   : "https://www.trekkie-trax.com/ep/trekkie152/"
+      track: "Talk",
+      url: "https://www.trekkie-trax.com/ep/trekkie152/",
     },
     {
-      index : 13,
+      index: 13,
       artist: "0b4k3 feat. kinu",
-      track : "voices",
-      url   : "https://0b4k3.bandcamp.com/track/voices-feat-kinu"
+      track: "voices",
+      url: "https://0b4k3.bandcamp.com/track/voices-feat-kinu",
     },
     {
-      index : 14,
+      index: 14,
       artist: "Carpainter",
-      track : "WAR DUB FROM THE NEW WORLD",
-      url   : "https://www.trekkie-trax.com/ep/trekkie12/"
+      track: "WAR DUB FROM THE NEW WORLD",
+      url: "https://www.trekkie-trax.com/ep/trekkie12/",
     },
     {
-      index : 15,
+      index: 15,
       artist: "you",
-      track : "Party Catapult",
-      url   : "https://lilium-rec.com/rave2/"
+      track: "Party Catapult",
+      url: "https://lilium-rec.com/rave2/",
     },
     {
-      index : 16,
+      index: 16,
       artist: "I WiSH",
-      track : "明日への扉 (山田結衣 & 加瀬友香 Cover) (Kacky 90's Style HappyHardcore Bootleg)",
-      url   : "https://soundcloud.com/kacky124/kacky-90s-style-happyhardcore-bootleg"
+      track:
+        "明日への扉 (山田結衣 & 加瀬友香 Cover) (Kacky 90's Style HappyHardcore Bootleg)",
+      url: "https://soundcloud.com/kacky124/kacky-90s-style-happyhardcore-bootleg",
     },
     {
-      index : 17,
+      index: 17,
       artist: "ETIA. feat. Jenga",
-      track : "On And On!! (Groundbreaking Edit)",
-      url   : "https://gdbg.tv/release/2018-8-2"
+      track: "On And On!! (Groundbreaking Edit)",
+      url: "https://gdbg.tv/release/2018-8-2",
     },
     {
-      index : 18,
+      index: 18,
       artist: "IOSYS TRAX, ちよこ",
-      track : "超野生！サバイバルずんど子ちゃん (Extended Mix)",
-      url   : "https://www.iosysos.com/discographyportal.php?cdno=IOTX-0006"
+      track: "超野生！サバイバルずんど子ちゃん (Extended Mix)",
+      url: "https://www.iosysos.com/discographyportal.php?cdno=IOTX-0006",
     },
     {
-      index : 19,
+      index: 19,
       artist: "NJ zEn",
-      track : "プルプルAction! シュランツ消臭ポッド",
-      url   : "https://dochakuso.net/release/dcks-0001.html"
+      track: "プルプルAction! シュランツ消臭ポッド",
+      url: "https://dochakuso.net/release/dcks-0001.html",
     },
     {
-      index : 20,
+      index: 20,
       artist: "Alicemetix",
-      track : "ラーメン二郎みたいなマッシュアップ",
-      url   : "https://soundcloud.com/mr_aaaa/jirou-mashup"
+      track: "ラーメン二郎みたいなマッシュアップ",
+      url: "https://soundcloud.com/mr_aaaa/jirou-mashup",
     },
     {
-      index : 21,
+      index: 21,
       artist: "Miniland",
-      track : "My Life",
-      url   : "https://aviencloudrecords.bandcamp.com/track/my-life"
+      track: "My Life",
+      url: "https://aviencloudrecords.bandcamp.com/track/my-life",
     },
     {
-      index : 22,
+      index: 22,
       artist: "Cab Calloway, Frank Froebe, Jack Palme",
-      track : "Jumpin' Jive (Played by 東京ディズニーシー ビッグバンドビート)",
-      url   : "https://www.universal-music.co.jp/p/uwcd-8119/"
+      track: "Jumpin' Jive (Played by 東京ディズニーシー ビッグバンドビート)",
+      url: "https://www.universal-music.co.jp/p/uwcd-8119/",
     },
     {
-      index : 23,
+      index: 23,
       artist: "ユニティちゃん",
-      track : "ありがとうございましたー！",
-      url   : "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack"
-    }
+      track: "ありがとうございましたー！",
+      url: "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack",
+    },
   ],
   galleryTwitter: [
     "1497520107203211265",
@@ -237,6 +241,6 @@ export const event: EventDetail = {
     "1499389603945467913",
     "1499388406048051201",
     "1499409304642011138",
-    "1499444836910321664"
-  ]
+    "1499444836910321664",
+  ],
 };

--- a/src/data/dj/details/2026/Virtual220.ts
+++ b/src/data/dj/details/2026/Virtual220.ts
@@ -1,297 +1,297 @@
 import { EventDetail } from "@/types/EventDetail";
 
 export const event: EventDetail = {
-  slug : "m4tt-and-friends-1",
+  slug: "m4tt-and-friends-1",
   title: "M4tt & Friends 9",
-  date : {
-    year : 2026,
+  date: {
+    year: 2026,
     month: 1,
-    day  : 9
+    day: 9,
   },
   time: {
     start: "21:00",
-    end  : "25:40"
+    end: "25:40",
   },
   place: {
-    name    : "RIPPLE 2",
+    name: "RIPPLE 2",
     platform: {
-      name    : "VRChat",
-      instance: "Friends+"
+      name: "VRChat",
+      instance: "Friends+",
     },
   },
   flyer: {
-    width : 1241,
+    width: 1241,
     height: 1241,
-    image : "/dj/2026/2026-VR-1.avif"
+    image: "/dj/2026/2026-VR-1.avif",
   },
   organizers: [
     {
       name: "M4tt",
-      url : "https://linktr.ee/M4Tyyyyy"
-    }
+      url: "https://linktr.ee/M4Tyyyyy",
+    },
   ],
-  support : [
+  support: [
     {
-      role  : "Singer",
+      role: "Singer",
       performers: [
         {
           name: "Aipo",
-          url : "https://x.com/aipo_vrc"
-        }
-      ]
+          url: "https://x.com/aipo_vrc",
+        },
+      ],
     },
     {
-      role  : "DJ",
+      role: "DJ",
       performers: [
         {
           name: "M4tt",
-          url : "https://linktr.ee/M4Tyyyyy"
+          url: "https://linktr.ee/M4Tyyyyy",
         },
         {
           name: "q330",
-          url : "https://x.com/q330vrc"
+          url: "https://x.com/q330vrc",
         },
         {
           name: "um",
-          url : "https://linktr.ee/umruumum"
+          url: "https://linktr.ee/umruumum",
         },
         {
-          name: "loser4dim"
-        }
-      ]
+          name: "loser4dim",
+        },
+      ],
     },
     {
-      role  : "VJ",
+      role: "VJ",
       performers: [
         {
           name: "Ende",
-          url : "https://poyandesuyo.com/"
+          url: "https://poyandesuyo.com/",
         },
         {
           name: "osirasekita",
-          url : "https://osirasekita.tumblr.com/"
-        }
-      ]
-    }
+          url: "https://osirasekita.tumblr.com/",
+        },
+      ],
+    },
   ],
   announcements: [
     {
       sns: "𝕏-Twitter",
-      url: "https://x.com/xM4Ty/status/2007769237285412905"
-    }
+      url: "https://x.com/xM4Ty/status/2007769237285412905",
+    },
   ],
   hashtags: ["M4ttFriends9", "VRChat"],
-  timeSlot: {
-    start   : "21:00",
-    end     : "26:00",
-    performs: [
-      {
-        start: "21:00",
-        end  : "21:50",
-        dj   : ["um"],
-        vj   : ["osirasekita"]
-      },
-      {
-        start: "22:00",
-        end  : "22:50",
-        dj   : ["loser4dim"],
-        vj   : ["Ende"]
-      },
-      {
-        start: "23:00",
-        end  : "23:50",
-        dj   : ["q330"],
-        vj   : ["osirasekita"]
-      },
-      {
-        start: "24:00",
-        end  : "24:40",
-        dj   : ["Aipo"],
-        vj   : ["Ende"]
-      },
-      {
-        start: "24:50",
-        end  : "25:40",
-        dj   : ["M4tt"],
-        vj   : ["osirasekita"]
-      }
-    ]
-  },
+  timeSlot: [
+    {
+      start: "21:00",
+      end: "26:00",
+      performs: [
+        {
+          start: "21:00",
+          end: "21:50",
+          dj: ["um"],
+          vj: ["osirasekita"],
+        },
+        {
+          start: "22:00",
+          end: "22:50",
+          dj: ["loser4dim"],
+          vj: ["Ende"],
+        },
+        {
+          start: "23:00",
+          end: "23:50",
+          dj: ["q330"],
+          vj: ["osirasekita"],
+        },
+        {
+          start: "24:00",
+          end: "24:40",
+          dj: ["Aipo"],
+          vj: ["Ende"],
+        },
+        {
+          start: "24:50",
+          end: "25:40",
+          dj: ["M4tt"],
+          vj: ["osirasekita"],
+        },
+      ],
+    },
+  ],
   setlist: [
     {
-      index : 0,
+      index: 0,
       artist: "ユニティちゃん",
-      track : "宜しくお願いしまーす！",
-      url   : "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack"
+      track: "宜しくお願いしまーす！",
+      url: "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack",
     },
     {
-      index : 1,
+      index: 1,
       artist: "Dj Santiago Cejas",
-      track : "The World Is Mine (Version Cumbia)",
-      url   : "https://www.youtube.com/watch?v=Azp1urN32BI"
+      track: "The World Is Mine (Version Cumbia)",
+      url: "https://www.youtube.com/watch?v=Azp1urN32BI",
     },
     {
-      index : 2,
+      index: 2,
       artist: "Nappy Nappy feat. Dj Santiago Cejas",
-      track : "Blue Bird (Version Cumbia)",
-      url   : "https://www.youtube.com/watch?v=POZZvGBwwSc"
+      track: "Blue Bird (Version Cumbia)",
+      url: "https://www.youtube.com/watch?v=POZZvGBwwSc",
     },
     {
-      index : 3,
+      index: 3,
       artist: "Dj Santiago Cejas",
-      track : "Butterfly Latino (Version Cumbia)",
-      url   : "https://www.youtube.com/watch?v=MRRq7nkUtT0"
+      track: "Butterfly Latino (Version Cumbia)",
+      url: "https://www.youtube.com/watch?v=MRRq7nkUtT0",
     },
     {
-      index : 4,
+      index: 4,
       artist: "Dj Santiago Cejas",
-      track : "TETORIS (Cumbia Remix)",
-      url   : "https://www.youtube.com/watch?v=OAnyM7XoQA4"
+      track: "TETORIS (Cumbia Remix)",
+      url: "https://www.youtube.com/watch?v=OAnyM7XoQA4",
     },
     {
-      index : 5,
+      index: 5,
       artist: "El Norteño Friki ",
-      track : "Si estuviésemos juntos (Cover norteño)",
-      url   : "https://soundcloud.com/cumbiabizarra/hatsune-miku-si-estuviesemos-juntos-cover-norteno"
+      track: "Si estuviésemos juntos (Cover norteño)",
+      url: "https://soundcloud.com/cumbiabizarra/hatsune-miku-si-estuviesemos-juntos-cover-norteno",
     },
     {
-      index : 6,
+      index: 6,
       artist: "Dj Santiago Cejas",
-      track : "Already Dead【Omae wa mou】 (Version Cumbia)",
-      url   : "https://www.youtube.com/watch?v=QnZbhZPr3Xc"
+      track: "Already Dead【Omae wa mou】 (Version Cumbia)",
+      url: "https://www.youtube.com/watch?v=QnZbhZPr3Xc",
     },
     {
-      index : 7,
+      index: 7,
       artist: "Dj Santiago Cejas",
-      track : "No Thank You (Cumbia)",
-      url   : "https://www.youtube.com/watch?v=06XrnzeyxJA"
+      track: "No Thank You (Cumbia)",
+      url: "https://www.youtube.com/watch?v=06XrnzeyxJA",
     },
     {
-      index : 8,
+      index: 8,
       artist: "El Norteño Friki ",
-      track : "Fullmetal Alchemist Brotherhood Norteño",
-      url   : "https://soundcloud.com/cumbiabizarra/fullmetal-alchemist-brotherhood-norteno"
+      track: "Fullmetal Alchemist Brotherhood Norteño",
+      url: "https://soundcloud.com/cumbiabizarra/fullmetal-alchemist-brotherhood-norteno",
     },
     {
-      index : 9,
+      index: 9,
       artist: "Madeon",
-      track : "Be Fine (cumbia remix)",
-      url   : "https://soundcloud.com/hirihiri/madeon-be-fine-cumbiaremix"
+      track: "Be Fine (cumbia remix)",
+      url: "https://soundcloud.com/hirihiri/madeon-be-fine-cumbiaremix",
     },
     {
-      index : 10,
+      index: 10,
       artist: "Skrillex",
-      track : "Mumbai Power (HAMAL's CUMBIA POWER Remix)",
-      url   : "https://soundcloud.com/hamal-music-official/skrillex-mumbai-power-hamals-cumbia-power-remix"
+      track: "Mumbai Power (HAMAL's CUMBIA POWER Remix)",
+      url: "https://soundcloud.com/hamal-music-official/skrillex-mumbai-power-hamals-cumbia-power-remix",
     },
     {
-      index : 11,
+      index: 11,
       artist: "S3RL",
-      track : "MTC (NortFriKi Remix) Pasito Duranguense Edit",
-      url   : "https://soundcloud.com/cumbiabizarra/s3rl-mtc-nortfriki-remix-pasito-duranguense-edit"
+      track: "MTC (NortFriKi Remix) Pasito Duranguense Edit",
+      url: "https://soundcloud.com/cumbiabizarra/s3rl-mtc-nortfriki-remix-pasito-duranguense-edit",
     },
     {
-      index : 12,
+      index: 12,
       artist: "DJ星空凛, kamoi",
-      track : "SAKURAスキップ (AniSoca Edit)"
+      track: "SAKURAスキップ (AniSoca Edit)",
     },
     {
-      index : 13,
+      index: 13,
       artist: "サトシ with ピカチュウ",
-      track : "アローラ!! (Eevees Soca Edit)",
-      url   : "https://soundcloud.com/eeeeveeees/eevees-soca-edit-3"
+      track: "アローラ!! (Eevees Soca Edit)",
+      url: "https://soundcloud.com/eeeeveeees/eevees-soca-edit-3",
     },
     {
-      index : 14,
+      index: 14,
       artist: "どうぶつビスケッツ, PPP",
-      track : "ようこそジャパリパークへ (LM Remix) (Promo_JP 2017)",
-      url   : "https://soundcloud.com/livingmirage/japari"
+      track: "ようこそジャパリパークへ (LM Remix) (Promo_JP 2017)",
+      url: "https://soundcloud.com/livingmirage/japari",
     },
     {
-      index : 15,
+      index: 15,
       artist: "Skrillex, Fred again.., Flowdan",
-      track : "Rumble (Funkot bootleg) (no intro)",
-      url   : "https://soundcloud.com/errorvator/skrillex-rumble-funkot-bootleg"
+      track: "Rumble (Funkot bootleg) (no intro)",
+      url: "https://soundcloud.com/errorvator/skrillex-rumble-funkot-bootleg",
     },
     {
-      index : 16,
+      index: 16,
       artist: "ruu_synthesizer",
-      track : "Yamaoka-House Anthem 2019",
-      url   : "https://www.mediafire.com/file/h9ytt6xpg04fh42/ruu_synthesizer_-_Yamaoka-House_Anthem_2019.mp3/file"
+      track: "Yamaoka-House Anthem 2019",
+      url: "https://www.mediafire.com/file/h9ytt6xpg04fh42/ruu_synthesizer_-_Yamaoka-House_Anthem_2019.mp3/file",
     },
     {
-      index : 17,
+      index: 17,
       artist: "Mr. Theater101",
-      track : "Funkot Tiw Tiw 2024",
-      url   : "https://soundcloud.com/mr-theater101-2/funkot-tiw-tiw-original-fixed-version"
+      track: "Funkot Tiw Tiw 2024",
+      url: "https://soundcloud.com/mr-theater101-2/funkot-tiw-tiw-original-fixed-version",
     },
     {
-      index : 18,
+      index: 18,
       artist: "Dj Ericnem",
-      track : "Apt Multiverse Budots Remix",
-      url   : "https://www.youtube.com/watch?v=PTuAB7vBI2s"
+      track: "Apt Multiverse Budots Remix",
+      url: "https://www.youtube.com/watch?v=PTuAB7vBI2s",
     },
     {
-      index : 19,
+      index: 19,
       artist: "Dj Ericnem",
-      track : "chicken dance budots",
-      url   : "https://djericnem.bandcamp.com/album/budots-remix"
+      track: "chicken dance budots",
+      url: "https://djericnem.bandcamp.com/album/budots-remix",
     },
     {
-      index : 20,
+      index: 20,
       artist: "DJ PANGIT",
-      track : "DRIFTVEIL CITY BUDOTS",
-      url   : "https://djpangit.bandcamp.com/album/budots-club-remixes-edits-vol-3"
+      track: "DRIFTVEIL CITY BUDOTS",
+      url: "https://djpangit.bandcamp.com/album/budots-club-remixes-edits-vol-3",
     },
     {
-      index : 21,
+      index: 21,
       artist: "Darude",
-      track : "SANDSTORM (DJ PANGIT BUDOTS REMIX)",
-      url   : "https://djpangit.bandcamp.com/album/budots-club-remixes-edits-vol-3"
+      track: "SANDSTORM (DJ PANGIT BUDOTS REMIX)",
+      url: "https://djpangit.bandcamp.com/album/budots-club-remixes-edits-vol-3",
     },
     {
-      index : 22,
+      index: 22,
       artist: "kuriso",
-      track : "Central cee BUDOTS REMIX 2024 (DASMAG VERSION)",
-      url   : "https://soundcloud.com/kxriso/central-cee-budots-remix-2024-dasmag-version"
+      track: "Central cee BUDOTS REMIX 2024 (DASMAG VERSION)",
+      url: "https://soundcloud.com/kxriso/central-cee-budots-remix-2024-dasmag-version",
     },
     {
-      index : 23,
+      index: 23,
       artist: "THE BUCKETHEADS",
-      track : "THE BOMB (DEAN REMIX)",
-      url   : "https://hypeddit.com/mmxh2f"
+      track: "THE BOMB (DEAN REMIX)",
+      url: "https://hypeddit.com/mmxh2f",
     },
     {
-      index : 24,
+      index: 24,
       artist: "ななひら",
-      track : "POKÉDANCE (Nagitsune Bassline Bootleg)"
+      track: "POKÉDANCE (Nagitsune Bassline Bootleg)",
     },
     {
-      index : 25,
+      index: 25,
       artist: "VHM4D",
-      track : "愛♡スクリ～ム！ (Budots)",
-      url   : "https://www.beatport.com/ja/track/budots/21098995"
+      track: "愛♡スクリ～ム！ (Budots)",
+      url: "https://www.beatport.com/ja/track/budots/21098995",
     },
     {
-      index : 26,
+      index: 26,
       artist: "スペシャルウィーク, サイレンススズカ, トウカイテイオー",
-      track : "うまぴょい伝説 (DJ Sky & Svillaxe Flip) (Extended)",
-      url   : "https://www.youtube.com/watch?v=l888dZe6Asw"
+      track: "うまぴょい伝説 (DJ Sky & Svillaxe Flip) (Extended)",
+      url: "https://www.youtube.com/watch?v=l888dZe6Asw",
     },
     {
-      index : 27,
+      index: 27,
       artist: "キティちゃん",
-      track : "みんなNAKAYOKU! (Special F Mix)",
-      url   : "https://mdb.tower.jp/release/11061178/KITTY-TRANCE"
+      track: "みんなNAKAYOKU! (Special F Mix)",
+      url: "https://mdb.tower.jp/release/11061178/KITTY-TRANCE",
     },
     {
-      index : 28,
+      index: 28,
       artist: "ユニティちゃん",
-      track : "ありがとうございましたー！",
-      url   : "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack"
-    }
+      track: "ありがとうございましたー！",
+      url: "https://unity-chan.com/download/releaseNote.php?id=UnitychanSuperUrikoVoicePack",
+    },
   ],
-  galleryTwitter: [
-    "2007769237285412905"
-  ]
+  galleryTwitter: ["2007769237285412905"],
 };

--- a/src/data/dj/details/2026/Virtual222.ts
+++ b/src/data/dj/details/2026/Virtual222.ts
@@ -1,120 +1,122 @@
 import { EventDetail } from "@/types/EventDetail";
 
 export const event: EventDetail = {
-  slug : "club-silhouette-23",
+  slug: "club-silhouette-23",
   title: "CLUB SILHOUETTE",
-  date : {
-    year : 2026,
+  date: {
+    year: 2026,
     month: 1,
-    day  : 18
+    day: 18,
   },
   time: {
     start: "23:00",
-    end  : "24:00"
+    end: "24:00",
   },
   place: {
-    name    : "CLUB-SILHOUETTE- 第１インスタンス",
+    name: "CLUB-SILHOUETTE- 第１インスタンス",
     platform: {
-      name    : "VRChat",
-      instance: "Friends"
+      name: "VRChat",
+      instance: "Friends",
     },
   },
   flyer: {
-    width : 1282,
+    width: 1282,
     height: 1920,
-    image : "/dj/club-silhouette.avif"
+    image: "/dj/club-silhouette.avif",
   },
   organizers: [
     {
       name: "LUMI*るみ*",
-      url : "https://www.foriio.com/lumi-vr"
-    }
+      url: "https://www.foriio.com/lumi-vr",
+    },
   ],
-  support : [
+  support: [
     {
-      role  : "DJ",
+      role: "DJ",
       performers: [
         {
           name: "Mazzn1987",
-          url : "https://lit.link/mazzn1987"
+          url: "https://lit.link/mazzn1987",
         },
         {
-          name: "loser4dim"
-        }
-      ]
-    }
+          name: "loser4dim",
+        },
+      ],
+    },
   ],
   announcements: [
     {
       sns: "𝕏-Twitter",
-      url: "https://x.com/vrc_silhouette/status/2010547292307431534"
-    }
+      url: "https://x.com/vrc_silhouette/status/2010547292307431534",
+    },
   ],
   hashtags: ["VRCシルエット", "VRChat"],
-  timeSlot: {
-    start   : "23:00",
-    end     : "24:00",
-    performs: [
-      {
-        start: "23:00",
-        end  : "23:30",
-        dj   : ["Mazzn1987"]
-      },
-      {
-        start: "23:30",
-        end  : "24:00",
-        dj   : ["loser4dim"]
-      }
-    ]
-  },
+  timeSlot: [
+    {
+      start: "23:00",
+      end: "24:00",
+      performs: [
+        {
+          start: "23:00",
+          end: "23:30",
+          dj: ["Mazzn1987"],
+        },
+        {
+          start: "23:30",
+          end: "24:00",
+          dj: ["loser4dim"],
+        },
+      ],
+    },
+  ],
   setlist: [
     {
-      index : 1,
+      index: 1,
       artist: "三宅優",
-      track : "塊オンザファンク (中塚武 edit)",
-      url   : "https://columbia.jp/katamari/"
+      track: "塊オンザファンク (中塚武 edit)",
+      url: "https://columbia.jp/katamari/",
     },
     {
-      index : 2,
+      index: 2,
       artist: "Alok, KENNY DOPE, Ella Eyre, Crystal Waters",
-      track : "Deep Down (Never Dull's In My Mind Edit)",
-      url   : "https://alokxellaeyrexkennydopexneverdull.lnk.to/DeepDown"
+      track: "Deep Down (Never Dull's In My Mind Edit)",
+      url: "https://alokxellaeyrexkennydopexneverdull.lnk.to/DeepDown",
     },
     {
-      index : 3,
+      index: 3,
       artist: "目黒将司",
-      track : "Pursuing My True Self (KARUT Remix)",
-      url   : "https://hypeddit.com/track/on8fi9"
+      track: "Pursuing My True Self (KARUT Remix)",
+      url: "https://hypeddit.com/track/on8fi9",
     },
     {
-      index : 4,
+      index: 4,
       artist: "The Seatbelts",
-      track : "Tank! (Musicarus Turbofunk Remix)",
-      url   : "https://soundcloud.com/mscrs/tnkrmx"
+      track: "Tank! (Musicarus Turbofunk Remix)",
+      url: "https://soundcloud.com/mscrs/tnkrmx",
     },
     {
-      index : 5,
+      index: 5,
       artist: "Mousse T., Hot'n'Juicy",
-      track : "98'Horny (Extended Mix)",
-      url   : "https://mousset.bandcamp.com/album/horny"
+      track: "98'Horny (Extended Mix)",
+      url: "https://mousset.bandcamp.com/album/horny",
     },
     {
-      index : 6,
+      index: 6,
       artist: "Chaz Jankel",
-      track : "Ai No Corrida (Malla's House Edit)",
-      url   : "https://mallauk.bandcamp.com/track/ai-no-corrida-mallas-house-edit"
+      track: "Ai No Corrida (Malla's House Edit)",
+      url: "https://mallauk.bandcamp.com/track/ai-no-corrida-mallas-house-edit",
     },
     {
-      index : 7,
+      index: 7,
       artist: "HI-RISE",
-      track : "I Believe In Miracles (The Time Stretch Kings In-Form Mix)",
-      url   : "https://www.discogs.com/release/123393-Hi-Rise-I-Believe-In-Miracles"
+      track: "I Believe In Miracles (The Time Stretch Kings In-Form Mix)",
+      url: "https://www.discogs.com/release/123393-Hi-Rise-I-Believe-In-Miracles",
     },
     {
-      index : 8,
+      index: 8,
       artist: "THE SQUARE",
-      track : "宝島 (ctx edit 2025)"
-    }
+      track: "宝島 (ctx edit 2025)",
+    },
   ],
   galleryTwitter: [
     "2010547292307431534",
@@ -152,6 +154,6 @@ export const event: EventDetail = {
     "2013831244480684228",
     "2013832330087985582",
     "2013833548931735625",
-    "2013853859756511427"
-  ]
+    "2013853859756511427",
+  ],
 };

--- a/src/types/EventDetail.ts
+++ b/src/types/EventDetail.ts
@@ -4,44 +4,44 @@ export type Person = {
 };
 
 export type EventDetail = {
-  slug : string
+  slug: string;
   title: string;
 
-  date : {
-    year : number;
+  date: {
+    year: number;
     month: number;
-    day  : number;
+    day: number;
   };
 
   time: {
     start: string;
-    end  : string;
+    end: string;
   };
 
   place: {
-    name?    : string;
-    url?     : string;
+    name?: string;
+    url?: string;
     platform?: {
-      name?    : string;
+      name?: string;
       instance?: string;
     };
   };
 
   flyer?: {
-    width : number;
+    width: number;
     height: number;
-    image : string;
+    image: string;
   };
 
   organizers: Person[];
 
-  group?    : {
+  group?: {
     name: string;
-    url : string;
+    url: string;
   };
 
-  support? : {
-    role      : string;
+  support?: {
+    role: string;
     performers: Person[];
   }[];
 
@@ -53,33 +53,33 @@ export type EventDetail = {
   hashtags?: string[];
 
   timetable?: {
-    width : number;
+    width: number;
     height: number;
-    image : string;
+    image: string;
   };
 
-  timeSlot?      : {
-    start   : string;
-    end     : string;
+  timeSlot?: {
+    start: string;
+    end: string;
     performs: {
       start: string;
-      end  : string;
-      dj   : string[];
-      vj?  : string[];
-    }[]
-  };
+      end: string;
+      dj: string[];
+      vj?: string[];
+    }[];
+  }[];
 
   mixArchives?: {
-    type    : "mixcloud" | "youtube" | "twitch" | "cloudflare";
+    type: "mixcloud" | "youtube" | "twitch" | "cloudflare";
     embedUrl: string;
   }[];
 
   setlist?: {
-    index : number;
+    index: number;
     artist: string;
-    track : string;
-    url?  : string;
+    track: string;
+    url?: string;
   }[];
 
-  galleryTwitter?: string[]
+  galleryTwitter?: string[];
 };


### PR DESCRIPTION
### Motivation
- Fix the timetable visual issue where a single timetable lane looks left-aligned and awkward, and make the layout look good for 1, 2, or 3 lanes. 
- Keep existing vertical time-mapping behavior (`top` / `height`) intact while improving horizontal layout. 
- Maintain the newer `timeSlot` array shape and ensure slots without both `start`/`end` do not crash rendering. 

### Description
- Derive column count from `timeSlots.length` (clamped to 1..3) and compute `timetableGridColumnsClass` and `timetableMaxWidthClass` to control grid columns and centered max widths. 
- Center the lane grid using `mx-auto` and apply per-column `max-w-*` presets so 1/2/3 column layouts render balanced, and replace previous fixed `md:grid-cols-2` usage with the computed classes. 
- Add `hasValidRangeTime` and `minutesToTime`, make `timeToMinutes` accept an optional string and return `0` for invalid input, compute `timelineStartMinutes`/`timelineEndMinutes` and `hourSteps` from `timeSlot` entries, and filter `performs` with `hasValidRangeTime` before rendering. 
- Update `EventDetail` types and multiple `src/data/dj/details/*` fixtures to the array-shaped `timeSlot` model and apply minor formatting/markup cleanups across the page. 

### Testing
- Ran `pnpm exec prettier --write src/app/dj/[slug]/page.tsx` which completed successfully. 
- Ran a full production build with `pnpm build` and Next.js compiled and generated pages successfully. 
- Started the dev server with `pnpm dev` to visually inspect the page and captured a Playwright screenshot for `/dj/practice`, all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69846a46bc7c83288ed60321adf1ef37)